### PR TITLE
Ver3 0 0

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
                   </div>
                   </div>
                   <!-- Development: Allow changing connection airport -->
-                  <div class="flex items-center gap-2 mb-2 hidden">
+                  <div class="flex items-center gap-2 mb-2">
                     <label class="inline-flex items-center gap-1 text-gray-700">
                       <input type="checkbox" id="allow-change-airport" class="h-4 w-4">
                       <span class="text-xs font-medium">Allow changing connection airport</span>

--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
                   <div class="flex items-center gap-2 mb-2">
                     <label class="inline-flex items-center gap-1 text-gray-700">
                       <input type="checkbox" id="allow-change-airport" class="h-4 w-4">
-                      <span class="text-xs font-medium">Allow changing connection airport</span>
+                      <span class="text-xs font-medium">Allow changing connection airport (for one stop routes only)</span>
                     </label>
                     <input
                       type="number"
@@ -268,6 +268,7 @@
                       placeholder="Radius km"
                       min="0"
                     >
+                    <div>KM</div>
                   </div>
                   <!-- Expert Settings -->
                   <button id="toggle-expert-settings" class="w-full bg-gray-200 text-gray-700 px-1 py-2 mb-2 rounded hover:bg-gray-300 focus:outline-none focus:ring-gray-400 cursor-pointer">

--- a/index.html
+++ b/index.html
@@ -259,16 +259,23 @@
                   <div class="flex items-center gap-2 mb-2">
                     <label class="inline-flex items-center gap-1 text-gray-700">
                       <input type="checkbox" id="allow-change-airport" class="h-4 w-4">
-                      <span class="text-xs font-medium">Allow changing connection airport (for one stop routes only)</span>
+                      <span class="text-xs font-medium">Allow changing connecting airport (one-stop routes only)</span>
                     </label>
+                    <div class="relative inline-block">
                     <input
                       type="number"
                       id="connection-radius"
-                      class="bg-gray-100 border border-gray-300 rounded px-1 py-1 w-20 text-right focus:ring-[#C90076] hidden"
-                      placeholder="Radius km"
+                      class="w-24 pr-8 bg-white border border-gray-300 rounded-lg px-2 py-1 text-right
+                            placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#C90076]
+                            focus:border-transparent transition"
+                      placeholder="Radius"
                       min="0"
-                    >
-                    <div>KM</div>
+                    />
+                    <span class="absolute inset-y-0 right-2 flex items-center text-gray-500 select-none">
+                      km
+                    </span>
+                  </div>
+
                   </div>
                   <!-- Expert Settings -->
                   <button id="toggle-expert-settings" class="w-full bg-gray-200 text-gray-700 px-1 py-2 mb-2 rounded hover:bg-gray-300 focus:outline-none focus:ring-gray-400 cursor-pointer">

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "All You Can Fly Pro (AYCF)",
     "description": "Chrome extension to easily find and book available routes for Wizz Air All-You-Can-Fly (AYCF) multipass subscribers.",
-    "version": "2.5.7",
+    "version": "3.0.0",
     "permissions": [
       "activeTab",
       "storage",

--- a/src/app.js
+++ b/src/app.js
@@ -3016,14 +3016,14 @@ function createSegmentRow(segment) {
       <div class="flex items-center gap-1 whitespace-normal">
         <div class="tooltip-trigger grid grid-cols-1 grid-rows-2 gap-0 items-center mr-1 relative">
           <span class="tooltip-trigger text-xl items-center flex -mb-1 cursor-pointer">${getCountryFlag(departureStationCode)}</span>
-          <div class="tooltip absolute hidden top-full min-w-[1rem] max-w-[10rem] left-0 bg-gray-800 text-white text-xs px-1 py-1 rounded shadow z-10 text-center whitespace-nowrap">
+          <div class="tooltip absolute hidden top-full min-w-[1rem] max-w-[10rem] left-0 bg-gray-800 text-white text-[8px] px-1 py-1 rounded shadow z-10 text-center whitespace-nowrap">
           ${getCountry(departureStationCode)}
           </div>
-          <span class="text-s justify-between items-center font-bold text-gray-500 -mt-1">${departureStationCode}</span>
+          <span class="text-[10px] justify-between items-center font-bold text-gray-500 -mt-1">${departureStationCode}</span>
         </div>
         <span class="text-base font-medium break-words max-w-[calc(100%-2rem)]">${segment.departureStationText}</span>
       </div>
-      <span class="-mb-8">
+      <span class="-mb-6">
       <svg xmlns="http://www.w3.org/2000/svg"
           class="block m-0 p-0"
           width="100%" height="100%"
@@ -3053,26 +3053,26 @@ function createSegmentRow(segment) {
             ${getCountryFlag(arrivalStationCode)}
           </span>
 
-          <div class="tooltip absolute hidden top-full right-0 min-w-[1rem] max-w-[10rem] bg-gray-800 text-white text-xs px-1 py-1 rounded shadow z-10 text-center whitespace-nowrap">
+          <div class="tooltip absolute hidden top-full right-0 min-w-[1rem] max-w-[10rem] bg-gray-800 text-white text-[8px] px-1 py-1 rounded shadow z-10 text-center whitespace-nowrap">
             ${getCountry(arrivalStationCode)}
           </div>
 
-          <span class="text-s justify-between items-center font-bold text-gray-500 -mt-1">
+          <span class="text-[10px] justify-between items-center font-bold text-gray-500 -mt-1">
             ${arrivalStationCode}
           </span>
         </div>
       </div>
     
-      <div class="flex items-center gap-1 mt-6">
+      <div class="flex items-center gap-1 mt-4">
         <span class="text-2xl font-bold whitespace-nowrap">${segment.displayDeparture}</span>
         <sup class="text-[10px] align-super">${formatOffsetForDisplay(segment.departureOffset)}</sup>
       </div>
-      <div class="flex flex-col items-center -mt-10">
+      <div class="flex flex-col items-center -mt-8">
         <div class="text-sm font-medium">
           ${segment.calculatedDuration.hours}h ${segment.calculatedDuration.minutes}m
         </div>
       </div>
-      <div class="flex items-center justify-end gap-1 mt-6">
+      <div class="flex items-center justify-end gap-1 mt-4">
         <span class="text-2xl font-bold whitespace-nowrap mb-0">${segment.displayArrival}</span>
         <sup class="text-[10px] align-super">${formatOffsetForDisplay(segment.arrivalOffset)}</sup>
       </div>

--- a/src/data/airports.js
+++ b/src/data/airports.js
@@ -124,6 +124,8 @@ export async function loadAirportsData() {
         code: dep.id,
         name: `${dep.name} (${dep.id})`,
         country: dep.country,
+        longitude: dep.longitude,
+        latitude: dep.latitude,
         flag: getCountryFlag(dep.country)
       });
     }


### PR DESCRIPTION
Version 3.0.0 Change log:
1. One-stop route flexibility
You can now change your connecting airport on one-stop (including overnight) itineraries. Just open the "Options" toolbar, enable "Allow changing connecting airport" checkbox, and specify the maximum transfer distance (in km) between airports.
2. Cleaner round-trip view
In round-trip searches, inbound flights are now hidden by default. Click the "Show inbound flights" button to expand and view them.